### PR TITLE
🎨 Palette: Improve Close Button Focus Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-23 - Focus Management in Vanilla JS Modals
 **Learning:** Simply appending a modal to the DOM doesn't shift focus. Keyboard users require explicit focus management: saving the active element before opening, forcing focus to the modal (or its close button) after opening, and restoring focus upon closing.
 **Action:** In `createPatternDesignerWindow` and similar utilities, capture `document.activeElement` at start, use `setTimeout` to focus the close button after DOM insertion, and restore the captured focus in the cleanup handler.
+
+## 2024-05-24 - Inline Styles and Focus Visibility
+**Learning:** When using `cssText` or inline styles to style interactive elements, browser default focus indicators may be overridden or become invisible (especially on dark backgrounds).
+**Action:** Always explicitly define `onfocus` and `onblur` handlers (or equivalent CSS) to ensure visible focus states (like `outline` or color changes) for keyboard users.

--- a/src/utils/designer.ts
+++ b/src/utils/designer.ts
@@ -126,7 +126,21 @@ export const createPatternDesignerWindow = (): HTMLDivElement => {
     };
 
     closeButton.onmouseenter = () => { closeButton.style.color = '#ffffff'; };
-    closeButton.onmouseleave = () => { closeButton.style.color = '#e0e0e0'; };
+    closeButton.onmouseleave = () => {
+        if (document.activeElement !== closeButton) {
+            closeButton.style.color = '#e0e0e0';
+        }
+    };
+
+    closeButton.onfocus = () => {
+        closeButton.style.color = '#ffffff';
+        closeButton.style.outline = '2px solid white';
+        closeButton.style.borderRadius = '4px';
+    };
+    closeButton.onblur = () => {
+        closeButton.style.color = '#e0e0e0';
+        closeButton.style.outline = 'none';
+    };
     titleBar.appendChild(closeButton);
 
     modal.appendChild(titleBar);

--- a/tests/unit/accessibility.test.ts
+++ b/tests/unit/accessibility.test.ts
@@ -91,4 +91,59 @@ describe('Pattern Designer Accessibility', () => {
 
         expect(document.activeElement).toBe(prevButton);
     });
+
+    it('should show visible focus styles on close button', () => {
+        const modal = createPatternDesignerWindow();
+        document.body.appendChild(modal);
+
+        const buttons = Array.from(modal.querySelectorAll('button'));
+        const closeButton = buttons.find(btn => btn.textContent === '×');
+
+        // Initial state
+        closeButton!.blur();
+        expect(closeButton!.style.outline).not.toBe('2px solid white');
+
+        // Focus state
+        closeButton!.focus();
+        // Trigger onfocus handler if it exists
+        closeButton!.dispatchEvent(new FocusEvent('focus'));
+
+        expect(closeButton!.style.outline).toBe('2px solid white');
+        expect(closeButton!.style.color).toBe('rgb(255, 255, 255)'); // #ffffff
+
+        // Blur state
+        closeButton!.blur();
+        closeButton!.dispatchEvent(new FocusEvent('blur'));
+
+        expect(closeButton!.style.outline).toBe('none');
+        expect(closeButton!.style.color).toBe('rgb(224, 224, 224)'); // #e0e0e0
+    });
+
+    it('should maintain white color on mouseleave if focused', () => {
+        const modal = createPatternDesignerWindow();
+        document.body.appendChild(modal);
+        const closeButton = Array.from(modal.querySelectorAll('button')).find(btn => btn.textContent === '×');
+
+        // Initial state
+        closeButton!.style.color = 'rgb(224, 224, 224)';
+
+        // Focus
+        closeButton!.focus();
+        closeButton!.dispatchEvent(new FocusEvent('focus'));
+        expect(closeButton!.style.color).toBe('rgb(255, 255, 255)'); // #ffffff
+
+        // Hover
+        closeButton!.dispatchEvent(new MouseEvent('mouseenter'));
+        expect(closeButton!.style.color).toBe('rgb(255, 255, 255)');
+
+        // Mouse leave
+        closeButton!.dispatchEvent(new MouseEvent('mouseleave'));
+        // Should still be white because it is focused
+        expect(closeButton!.style.color).toBe('rgb(255, 255, 255)');
+
+        // Blur
+        closeButton!.blur();
+        closeButton!.dispatchEvent(new FocusEvent('blur'));
+        expect(closeButton!.style.color).toBe('rgb(224, 224, 224)'); // #e0e0e0
+    });
 });


### PR DESCRIPTION
Improved the accessibility of the Pattern Designer (About) window by adding visible focus styles to the Close button. This ensures keyboard users can see when the close button is focused. Also fixed a visual inconsistency where unhovering while focused would dim the button text.

Changes:
- `src/utils/designer.ts`: Added `onfocus`/`onblur` and updated `onmouseleave`.
- `tests/unit/accessibility.test.ts`: Added tests.
- `.Jules/palette.md`: Added journal entry.

---
*PR created automatically by Jules for task [5923926387909283979](https://jules.google.com/task/5923926387909283979) started by @AEmotionStudio*